### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/wtznc/macOS-activity-tracker/security/code-scanning/1](https://github.com/wtznc/macOS-activity-tracker/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow does not require write access, we can set the permissions to `contents: read`, which is the minimal privilege required for the `actions/checkout@v4` step. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
